### PR TITLE
Business Intelligence Compute Table

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -35,6 +35,7 @@ def register():
         table.TableGroup,
         table.TableParameters,
         table.TableQueryParameter,
+        table.ParametrizeTableStart,
         table.Cluster,
         table.Table,
         table.Field,

--- a/babi.xml
+++ b/babi.xml
@@ -22,7 +22,7 @@ contains the full copyright notices and license terms. -->
             <field name="name">Business Intelligence Table</field>
         </record>
         <record model="res.group" id="group_babi_table_compute">
-            <field name="name">Business Intelligence Compute Table</field>
+            <field name="name">Allow calculating tables</field>
         </record>
 
         <!-- babi.expression -->

--- a/babi.xml
+++ b/babi.xml
@@ -21,6 +21,9 @@ contains the full copyright notices and license terms. -->
         <record model="res.group" id="group_babi_table">
             <field name="name">Business Intelligence Table</field>
         </record>
+        <record model="res.group" id="group_babi_table_compute">
+            <field name="name">Business Intelligence Compute Table</field>
+        </record>
 
         <!-- babi.expression -->
         <record model="ir.ui.view" id="babi_expression_form_view">

--- a/locale/ca.po
+++ b/locale/ca.po
@@ -1713,8 +1713,8 @@ msgid "Business Intelligence Table"
 msgstr "Taula de Business Intelligence"
 
 msgctxt "model:res.group,name:group_babi_table_compute"
-msgid "Business Intelligence Compute Table"
-msgstr "Taula de càlcul de Business Intelligence"
+msgid "Allow calculating tables"
+msgstr "Permetre calcular taules"
 
 msgctxt "model:www.download_report,name:"
 msgid "Download Report"

--- a/locale/ca.po
+++ b/locale/ca.po
@@ -1712,6 +1712,10 @@ msgctxt "model:res.group,name:group_babi_table"
 msgid "Business Intelligence Table"
 msgstr "Taula de Business Intelligence"
 
+msgctxt "model:res.group,name:group_babi_table_compute"
+msgid "Business Intelligence Compute Table"
+msgstr "Taula de càlcul de Business Intelligence"
+
 msgctxt "model:www.download_report,name:"
 msgid "Download Report"
 msgstr "Descarrega l'informe"

--- a/locale/es.po
+++ b/locale/es.po
@@ -1713,6 +1713,10 @@ msgctxt "model:res.group,name:group_babi_table"
 msgid "Business Intelligence Table"
 msgstr "Tabla de Business Intelligence"
 
+msgctxt "model:res.group,name:group_babi_table_compute"
+msgid "Business Intelligence Compute Table"
+msgstr "Tabla de cálculo de Business Intelligence"
+
 msgctxt "model:www.download_report,name:"
 msgid "Download Report"
 msgstr "Descargar informe"

--- a/locale/es.po
+++ b/locale/es.po
@@ -1714,8 +1714,8 @@ msgid "Business Intelligence Table"
 msgstr "Tabla de Business Intelligence"
 
 msgctxt "model:res.group,name:group_babi_table_compute"
-msgid "Business Intelligence Compute Table"
-msgstr "Tabla de cálculo de Business Intelligence"
+msgid "Allow calculating tables"
+msgstr "Permitir calcular tablas"
 
 msgctxt "model:www.download_report,name:"
 msgid "Download Report"

--- a/table.py
+++ b/table.py
@@ -3,6 +3,7 @@ import pytz
 import time
 import traceback
 import datetime as mdatetime
+from contextlib import nullcontext
 from datetime import date, datetime, time as dt_time, timedelta
 import logging
 import sql
@@ -23,7 +24,7 @@ from openpyxl.cell.cell import ILLEGAL_CHARACTERS_RE
 from simpleeval import EvalWithCompoundTypes
 from trytond import backend
 from trytond.bus import notify
-from trytond.transaction import Transaction
+from trytond.transaction import Transaction, without_check_access
 from trytond.pool import Pool
 from trytond.model import (Exclude, Model, ModelView, ModelSQL, fields,
     Unique, DeactivableMixin, sequence_ordered, Workflow)
@@ -590,6 +591,25 @@ class Table(DeactivableMixin, ModelSQL, ModelView):
         return 'xlsx'
 
     @classmethod
+    def _compute_access_context(cls):
+        pool = Pool()
+        ModelAccess = pool.get('ir.model.access')
+        ModelData = pool.get('ir.model.data')
+        User = pool.get('res.user')
+
+        transaction = Transaction()
+        if not transaction.user or ModelAccess.check(
+                cls.__name__, 'write', raise_exception=False):
+            return nullcontext()
+
+        group_babi_table_compute = ModelData.get_id(
+            'babi', 'group_babi_table_compute')
+        user = User(transaction.user)
+        if any(group.id == group_babi_table_compute for group in user.groups):
+            return without_check_access()
+        return nullcontext()
+
+    @classmethod
     def __setup__(cls):
         super().__setup__()
         cls._order.insert(0, ('name', 'ASC'))
@@ -1041,7 +1061,6 @@ class Table(DeactivableMixin, ModelSQL, ModelView):
         pool = Pool()
         ModelData = pool.get('ir.model.data')
         Action = pool.get('ir.action')
-
         for table in tables:
             if ((table.filter and table.filter.parameters
                     and not table.parameters)
@@ -1243,60 +1262,60 @@ class Table(DeactivableMixin, ModelSQL, ModelView):
         raise TimeoutException
 
     def _compute(self, compute_warnings=False, cluster=False):
-        self.clear_cache([self])
-        start_time = time.time()
-        try:
-            if self.type == 'model':
-                if not self.fields_:
-                    raise UserError(gettext('babi.msg_table_no_fields',
-                            table=self.name))
-                self._compute_model()
-            elif self.type == 'table':
-                self._compute_table()
-            elif self.type == 'view':
-                self._compute_view()
+        with self.__class__._compute_access_context():
+            self.clear_cache([self])
+            start_time = time.time()
+            try:
+                if self.type == 'model':
+                    if not self.fields_:
+                        raise UserError(gettext('babi.msg_table_no_fields',
+                                table=self.name))
+                    self._compute_model()
+                elif self.type == 'table':
+                    self._compute_table()
+                elif self.type == 'view':
+                    self._compute_view()
 
-        except Exception as e:
-            # In case there is a create view error or SQL typo,
-            # we do rollback to obtain a value from the gettext()
-            Transaction().connection.rollback()
-            notify(gettext('babi.msg_table_failed', table=self.rec_name))
-            self.compute_error = f'{e}\n{traceback.format_exc()}'
-            self.save()
+            except Exception as e:
+                # In case there is a create view error or SQL typo,
+                # we do rollback to obtain a value from the gettext()
+                Transaction().connection.rollback()
+                notify(gettext('babi.msg_table_failed', table=self.rec_name))
+                self.compute_error = f'{e}\n{traceback.format_exc()}'
+                self.save()
+                if cluster and self.cluster:
+                    self.cluster.computation_end_date = datetime.now()
+                    self.cluster.computation_state = 'failed'
+                    self.cluster.save()
+                return
+
             if cluster and self.cluster:
-                self.cluster.computation_end_date = datetime.now()
-                self.cluster.computation_state = 'failed'
-                self.cluster.save()
-            return
+                next_ = self.get_next_in_cluster()
+                if next_:
+                    next_.cluster_date = self.cluster_date
+                    next_.save()
+                    self.__class__.__queue__._compute(next_,
+                        compute_warnings=compute_warnings, cluster=cluster)
+                else:
+                    self.cluster.computation_end_date = datetime.now()
+                    self.cluster.computation_state = 'successful'
+                    self.cluster.save()
 
-        if cluster and self.cluster:
-            next_ = self.get_next_in_cluster()
-            if next_:
-                next_.cluster_date = self.cluster_date
-                next_.save()
-                self.__class__.__queue__._compute(next_,
-                    compute_warnings=compute_warnings, cluster=cluster)
-            else:
-                self.cluster.computation_end_date = datetime.now()
-                self.cluster.computation_state = 'successful'
-                self.cluster.save()
-
-        self.compute_error = None
-        self.compute_warning_error = None
-        end_time = time.time()
-        self.save()
-        notify(gettext('babi.msg_table_successful', table=self.rec_name))
-        self.calculation_date = datetime.now()
-        self.calculation_time = round(end_time - start_time,
-            self.__class__.calculation_time.digits[1])
-        self.save()
-        if compute_warnings:
-            self.__class__.__queue__.compute_warnings(self)
+            self.compute_error = None
+            self.compute_warning_error = None
+            end_time = time.time()
+            self.save()
+            notify(gettext('babi.msg_table_successful', table=self.rec_name))
+            self.calculation_date = datetime.now()
+            self.calculation_time = round(end_time - start_time,
+                self.__class__.calculation_time.digits[1])
+            self.save()
+            if compute_warnings:
+                self.__class__.__queue__.compute_warnings(self)
 
     def compute_warnings(self):
         pool = Pool()
         Warning = pool.get('babi.warning')
-
         self.compute_warning_error = None
         self.save()
         query = self.get_query()
@@ -2613,7 +2632,7 @@ class OpenExecutionFiltered(StateView):
                 Button('Cancel', 'end', 'tryton-cancel'),
                 Button('Create', 'create_table', 'tryton-ok', True),
                 ]
-        super().__init__('babi.table', 0, buttons)
+        super().__init__('babi.table.parametrize.start', 0, buttons)
 
     def get_view(self, wizard, state_name):
         pool = Pool()
@@ -2627,7 +2646,7 @@ class OpenExecutionFiltered(StateView):
         result = {}
         result['type'] = 'form'
         result['view_id'] = None
-        result['model'] = 'babi.table'
+        result['model'] = 'babi.table.parametrize.start'
         result['field_childs'] = None
         fields = {}
         parameter2report = {}
@@ -2730,6 +2749,11 @@ class CustomDict(dict):
 
     def __setattr__(self, name, value):
         self[name] = value
+
+
+class ParametrizeTableStart(ModelView):
+    'Babi Parametrize Table Start'
+    __name__ = 'babi.table.parametrize.start'
 
 
 class ParametrizeTable(Wizard):

--- a/table.xml
+++ b/table.xml
@@ -151,6 +151,14 @@
             <field name="perm_create" eval="True"/>
             <field name="perm_delete" eval="True"/>
         </record>
+        <record model="ir.model.access" id="access_babi_table_babi_table_compute">
+            <field name="model">babi.table</field>
+            <field name="group" ref="group_babi_table_compute"/>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_delete" eval="False"/>
+        </record>
 
         <record model="ir.rule.group" id="rule_group_babi_table">
             <field name="name">Babi Table</field>
@@ -175,6 +183,14 @@
             <field name="name">compute</field>
             <field name="string">Compute</field>
             <field name="model">babi.table</field>
+        </record>
+        <record model="ir.model.button-res.group" id="babi_table_calculate_button_group_babi_admin">
+            <field name="button" ref="babi_table_calculate_button"/>
+            <field name="group" ref="group_babi_admin"/>
+        </record>
+        <record model="ir.model.button-res.group" id="babi_table_calculate_button_group_babi_table_compute">
+            <field name="button" ref="babi_table_calculate_button"/>
+            <field name="group" ref="group_babi_table_compute"/>
         </record>
         <record model="ir.model.button" id="babi_table_calculate_warning_button">
             <field name="name">compute_warning</field>
@@ -423,6 +439,14 @@
         <record model="ir.action.wizard" id="table_parametrize_wizard">
             <field name="name">Parametrize Table</field>
             <field name="wiz_name">babi.table.parametrize</field>
+        </record>
+        <record model="ir.action-res.group" id="table_parametrize_wizard_group_babi_admin">
+            <field name="action" ref="table_parametrize_wizard"/>
+            <field name="group" ref="group_babi_admin"/>
+        </record>
+        <record model="ir.action-res.group" id="table_parametrize_wizard_group_babi_table_compute">
+            <field name="action" ref="table_parametrize_wizard"/>
+            <field name="group" ref="group_babi_table_compute"/>
         </record>
 
         <record model="ir.action.act_window" id="act_babi_table_parametrized">


### PR DESCRIPTION
#189318
Add Business Intelligence Compute Table group to let selected users run BABI table computations without granting full edit access on babi.table (perm_write to false). The change also updates button, wizard, and access rules so compute and parameterized compute flows work for this group while keeping regular table modification restricted.